### PR TITLE
Parse for titles: Add ability to retrieve up to 200 tweets and parse through titles in stable manner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'underscore-rails'
 
 # gem 'nokogiri'
 gem 'oga'
+gem 'open_uri_redirections'
 
 gem 'haml'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     omniauth-twitter (1.1.0)
       multi_json (~> 1.3)
       omniauth-oauth (~> 1.0)
+    open_uri_redirections (0.2.1)
     pg (0.18.3)
     phantomjs (1.9.8.0)
     rack (1.6.4)
@@ -234,6 +235,7 @@ DEPENDENCIES
   jquery-rails
   oga
   omniauth-twitter (~> 1.1.0)
+  open_uri_redirections
   pg
   rails (= 4.2.4)
   rails-backbone

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,5 +1,6 @@
 require 'open-uri'
-require 'net/http'
+require 'open_uri_redirections'
+# require 'net/http'
 
 class Link
 
@@ -9,9 +10,8 @@ class Link
   end
 
   def grab_title
-    p @url
     begin
-      body = open(@url).read
+      body = open(@url, :allow_redirections => :all).read
     rescue => e
       case e
       when OpenURI::HTTPError
@@ -23,7 +23,11 @@ class Link
       end
     end
     doc = Oga.parse_html(body)
-    p html_title = doc.at_css('title').text
+    if doc.at_css('title') != nil
+      p html_title = doc.at_css('title').text
+    else
+      return @url
+    end
   end
 
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -14,7 +14,7 @@ class Tweet
       created_at = tweet.created_at
       urls = self.expanded_urls(tweet)
       link_titles = self.scrape_urls_for_titles(urls)
-      p text = tweet.text
+      text = tweet.text
       user_profile_image_url = tweet.user.profile_image_url.to_s
       Tweet.new(created_at: created_at, urls: urls, text: text, user_profile_image_url: user_profile_image_url, link_titles: link_titles)
     end


### PR DESCRIPTION
Used Oga to parse through the returned tweets because it seemed much more stable than Nokogiri. Added additional checks to stablize process to make sure HTTP errors and Socket errors do not cause crashing during scraping process. Finally, web sites with no titles now return url instead of crashing the scrape. All of this allows us to know use our Twitter api to return us 200 tweets.
