### PR TITLE
Add ability to tweet found search results at searched handle.

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -45,6 +45,9 @@ $(document).ready(function() {
 
 
   $("#temporary-container").on("click", ".keyword", function(event){
+
+    var twitterHandle = $("#search-bar").val();
+
     event.preventDefault();
     var value = $(this).val();
     if(keywords.indexOf(value) > -1){
@@ -62,12 +65,19 @@ $(document).ready(function() {
     if (query.length > 0){
       results.fetch({
           reset: true,
-          data: $.param({ query: query })
+          data: $.param({ query: query, handle: twitterHandle })
       });
     }
-
-
   })
+
+  $("#twitter-button").on("click", function(event){
+    event.preventDefault();
+    var twitterHandle = $("#search-bar").val();
+    // if (twitterHandle.match(/^[@]/)){
+
+    // }
+    $(this).attr('href').append(twitterHandle)
+  });
 
 
 });

--- a/app/assets/javascripts/templates/search_result.jst.ejs
+++ b/app/assets/javascripts/templates/search_result.jst.ejs
@@ -1,10 +1,14 @@
 <li class="search-result">
     <div class="result-content">
-
       <p>
-        <a href="<%= url %>"><%= title %></a>
+        <a href="<%= url %>" target="_blank"><%= title %></a>
         <br>
         <span class="description"><%= description %></span>
+        <br>
+
+        <a id="twitter-button" href="https://twitter.com/share?url=<%=url%>&text=Check this out! <%=handle%>" data-url="<%=url%>" class="twitter-share-button">TWEET THIS TO <%=handle%></a>
+
+
       </p>
     </div>
   </li>

--- a/app/assets/javascripts/templates/tweet.jst.ejs
+++ b/app/assets/javascripts/templates/tweet.jst.ejs
@@ -3,10 +3,10 @@
     <img class="profile-pic" src="<%= user_profile_image_url %>" alt="">
     <div class="tweet-content">
       <p>
-        <span class="test"><%= text %></span>
+        <h1><span class="test"><%= text %></span>
         <br>
         <a href="<%= link_titles[0].url %>" class="test"><%= link_titles[0].title %></a>
-        <%= console.log(link_titles[0]) %>
+        <%= console.log(link_titles[0]) %></h1>
       </p>
       <ul class="result-keywords">
           <% for (var i=0; i< keywords.length; i++) { %>

--- a/app/controllers/bing_results_controller.rb
+++ b/app/controllers/bing_results_controller.rb
@@ -1,7 +1,7 @@
 class BingResultsController < ApplicationController
 
   def index
-    p render json: BingResult.all_results(params[:query])
+    p render json: BingResult.all_results(params[:query], params[:handle])
     # BingResult.all_results(params[:query]).each do |result|
     #   p result.title
     #   p result.description

--- a/app/models/bing_result.rb
+++ b/app/models/bing_result.rb
@@ -1,15 +1,16 @@
 require 'highscore'
 
 class BingResult
-  attr_accessor :title, :description, :url, :keywords
+  attr_reader :title, :description, :url, :keywords, :handle
 
   def initialize(attributes)
     @title = attributes[:title]
     @description = attributes[:description]
     @url = attributes[:url]
+    @handle = attributes[:handle]
   end
 
-  def self.all_results(query)
+  def self.all_results(query, handle)
     BingSearch.account_key = ENV['BING_ACCOUNT_KEY']
     results = []
     bing_search = BingSearch.web(query)
@@ -17,9 +18,9 @@ class BingResult
       title = bing_search[count].title
       description = bing_search[count].description
       url = bing_search[count].url
-      results << BingResult.new(title: title, description: description, url: url)
+      results << BingResult.new(title: title, description: description, url: url, handle: handle)
     end
-    p results
+    results
   end
 
 

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -3,7 +3,7 @@ class Tweet
   def initialize(attributes)
     @created_at = attributes[:created_at]
     @urls = attributes[:urls]
-    # @user_mentions = attributes[:user_mentions]
+    @user_mentions = attributes[:user_mentions]
     @text = attributes[:text]
     @user_profile_image_url = attributes[:user_profile_image_url]
     @link_titles = attributes[:link_titles]
@@ -13,12 +13,13 @@ class Tweet
 
   def self.all_tweets(handle)
     self.client.user_timeline(handle, { count: 40, include_rts: false }).map do |tweet|
+      p tweet.user_mentions
       created_at = tweet.created_at
       urls = self.expanded_urls(tweet)
       link_titles = self.scrape_urls_for_titles(urls)
       text = tweet.text
       if link_titles.length == 0
-        p "UHHHHH"
+        # do nothing
       else
         p title = link_titles[0].grab_title
         title_keywords = title.keywords

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
+
   </head>
   <body>
     <%= yield %>


### PR DESCRIPTION
Each search result is rendered with a twitter share button that will auto-populate with the correct URL and twitter handle of the person originally searched to generate the keywords. Before, no tweet button was available and users could not tweet. This commit adds the functionality to tweet at the correct handle, and with the correct link. With this commit we finish our MVP.
