### PR TITLE
Add logic to empty search results container when all keywords are uns…

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -43,7 +43,6 @@ $(document).ready(function() {
   });
 
   $("#temporary-container").on("click", ".keyword", function(event){
-
     var twitterHandle = $("#search-bar").val();
 
     event.preventDefault();
@@ -52,6 +51,9 @@ $(document).ready(function() {
       var index = keywords.indexOf(value);
       keywords.splice(index, 1)
       $(this).removeClass("active-keyword")
+      if(keywords.length === 0 || keywords.first === ""){
+      $("#search-results-container").empty();
+    }
     } else {
       $(this).addClass("active-keyword");
       keywords.push(value);


### PR DESCRIPTION
…elected.

A user could unclick keywords, but when s/he unclicked the last 'active' keyword button, the search results container would stay stuck on the last search. The search results container will now empty when the user unchecks the last checked keyword.
