### PR TITLE
Grab elements from links using the meta-inspector gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'bing-search'
 
 gem 'highscore'
 
+gem 'metainspector'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,13 @@ GEM
     execjs (2.6.0)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    fastimage (1.7.0)
+      addressable (~> 2.3, >= 2.3.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.7)
@@ -106,6 +113,13 @@ GEM
       mime-types (>= 1.16, < 3)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
+    metainspector (4.6.1)
+      addressable (~> 2.3.5)
+      faraday (~> 0.9.0)
+      faraday-cookie_jar (~> 0.0.6)
+      faraday_middleware (~> 0.10)
+      fastimage
+      nokogiri (~> 1.6)
     mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (5.8.0)
@@ -241,6 +255,7 @@ DEPENDENCIES
   jasmine-rails
   jbuilder (~> 2.0)
   jquery-rails
+  metainspector
   oga
   omniauth-twitter (~> 1.1.0)
   open_uri_redirections
@@ -257,3 +272,6 @@ DEPENDENCIES
   underscore-rails
   unirest
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/assets/blacklist.txt
+++ b/app/assets/blacklist.txt
@@ -1,0 +1,34 @@
+again
+to
+and
+also
+then
+equally
+identically
+uniquely
+like
+as
+too
+moreover
+"as well as"
+"together with"
+"of course"
+likewise
+comparatively
+correspondingly
+similarly
+furthermore
+additionally
+"in the first place"
+"not only ... but also"
+"as a matter of fact"
+"in like manner"
+"in addition"
+"coupled with"
+"in the same fashion / way"
+"first, second, third"
+"in the light of"
+"not to mention"
+"to say nothing of"
+"equally important"
+"by the same token"

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,7 +2,7 @@ class TweetsController < ApplicationController
 
   def index
     tweets = Tweet.all_tweets(params[:handle])
-    current_user.update_attributes(target_tweets: tweets)
+    current_user.update_attributes(target_tweets: tweets) if current_user
     render json: tweets
   end
 

--- a/app/helpers/blacklist_helper.rb
+++ b/app/helpers/blacklist_helper.rb
@@ -1,0 +1,5 @@
+module BlacklistHelper
+  def blacklist_load
+    blacklist = Highscore::Blacklist.load_file "../assets/blacklist.txt"
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -7,30 +7,32 @@ class Link
   attr_reader :title
   def initialize(url)
     @url = url
-    @title = grab_title
+    @page = MetaInspector.new(url)
+    # @title = grab_title
+    @title = @page.title
   end
 
-  def grab_title
-    begin
-      body = open(@url, :allow_redirections => :all).read
-    rescue => e
-      case e
-      when OpenURI::HTTPError
-        return @url
-      when SocketError
-        return @url
-      else
-        raise e
-      end
-    end
-    doc = Oga.parse_html(body)
-    html_title = doc.at_css('title').text
-    html_title
-    if doc.at_css('title') != nil
-      html_title = doc.at_css('title').text
-    else
-      return @url
-    end
-  end
+  # def grab_title
+  #   begin
+  #     body = open(@url, :allow_redirections => :all).read
+  #   rescue => e
+  #     case e
+  #     when OpenURI::HTTPError
+  #       return @url
+  #     when SocketError
+  #       return @url
+  #     else
+  #       raise e
+  #     end
+  #   end
+  #   doc = Oga.parse_html(body)
+  #   html_title = doc.at_css('title').text
+  #   html_title
+  #   if doc.at_css('title') != nil
+  #     html_title = doc.at_css('title').text
+  #   else
+  #     return @url
+  #   end
+  # end
 
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -38,7 +38,7 @@ class Tweet
       text: self.tweet_text(tweet),
       user_profile_image_url: self.profile_image_url(tweet),
       links: links,
-      text_keywords: self.text_keywords(tweet),
+      text_keywords: self.text_keywords(tweet_text(tweet)),
       title_keywords: self.title_keywords(links)
     }
   end
@@ -69,8 +69,8 @@ class Tweet
     urls.map { |url| Link.new(url) }
   end
 
-  def self.text_keywords(tweet)
-    tweet.text.keywords.rank.map { |word| word.text }
+  def self.text_keywords(tweet_text)
+    tweet_text.keywords.rank.map { |word| word.text }
   end
 
   def self.title_keywords(links)


### PR DESCRIPTION
Not all twitter handels were searchable because of the fragility of our parsing logic. We are no longer using the oga gem and are using meta-inspector.
