### PR TITLE
Return tweet rendering to prior state.

### DIFF
--- a/app/assets/javascripts/templates/tweet.jst.ejs
+++ b/app/assets/javascripts/templates/tweet.jst.ejs
@@ -1,10 +1,15 @@
 <% if (links.length > 0){ %>
   <li class="tweet">
+    <img class="profile-pic" src="<%= target_profile_image_url %>" alt="">
     <div class="tweet-content">
       <p>
-        <%= embedded_tweet %><br>
 
-        <a href="<%= links[0].url %>" class="test"><%= links[0].title %></a>
+        <h3>
+        <%= target_name %> posted <a href="<%= links[0].url %>" class="test"><%= links[0].title %></a></h3>
+        <h4><p><%= text %></p></h4>
+        <p>tweeted on <%= created_at %></p>
+
+      </h1>
       </p>
       <ul class="result-keywords">
           <% for (var i=0; i< text_keywords.length; i++) { %>

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -26,9 +26,9 @@ class Link
         raise e
       end
     end
+
     doc = Oga.parse_html(body)
-    html_title = doc.at_css('title').text
-    html_title
+
     if doc.at_css('title') != nil
       html_title = doc.at_css('title').text
     else

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -4,7 +4,7 @@ class Tweet
   attr_reader :target_id, :target_handle, :target_name, :user_mentions, :target_profile_image_url
 
   def initialize(attributes)
-    @embedded_tweet = attributes[:embedded_tweet]
+    # @embedded_tweet = attributes[:embedded_tweet]
     @target_id = attributes[:target_id]
     @target_handle = attributes[:handle]
     @target_name = attributes[:target_name]
@@ -30,7 +30,7 @@ class Tweet
     links = self.tweet_links(tweet)
 
     {
-      embedded_tweet: self.client.oembed("#{tweet.id}").html,
+      # embedded_tweet: Clientable.client.oembed("#{tweet.id}").html,
       target_id: tweet.user.id,
       target_handle: tweet.user.screen_name,
       target_name: tweet.user.name,


### PR DESCRIPTION
When embedding tweets we made far too many requests to the Twitter API and quickly exceeded our limit. By returning to the previous scraping strategy we make fewer requests and grab more tweets with each request, making it easier to stay within our limit. We lose the ability to embed videos, and reply to tweets.
